### PR TITLE
Install protoc

### DIFF
--- a/.github/workflows/jni_artifacts.yml
+++ b/.github/workflows/jni_artifacts.yml
@@ -54,6 +54,12 @@ jobs:
       run: choco install nasm
       shell: cmd
 
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        version: '3.x'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
     - run: cargo build --release -p libsignal-jni
 
     - run: cargo build --release -p libsignal-jni --target aarch64-apple-darwin


### PR DESCRIPTION
The protobuf compiler must be installed to be able to compile the grpc proto files.