### PR TITLE
gRPC response with bytes instead of string

### DIFF
--- a/rust/grpc/src/client.rs
+++ b/rust/grpc/src/client.rs
@@ -80,7 +80,7 @@ impl GrpcClient {
         let mut result = vec![];
 
         result.extend(response.get_ref().statuscode.to_be_bytes());
-        result.extend(response.get_ref().message.as_bytes());
+        result.extend(&response.get_ref().message);
 
         Ok(result)
     }

--- a/rust/grpc/src/proto/proxy.proto
+++ b/rust/grpc/src/proto/proxy.proto
@@ -29,5 +29,5 @@ message SignalRpcMessage {
 
 message SignalRpcReply {
   int32 statuscode = 1;
-  string message = 2;
+  bytes message = 2;
 }


### PR DESCRIPTION
The SignalRpcResponse message uses bytes instead of a string for the message field.