### PR TITLE
Produce artifact per target

### DIFF
--- a/java/build_jni.sh
+++ b/java/build_jni.sh
@@ -13,7 +13,7 @@ cd "${SCRIPT_DIR}"/..
 
 # These paths are relative to the root directory
 ANDROID_LIB_DIR=java/android/src/main/jniLibs
-DESKTOP_LIB_DIR=java/client/src/main/resources
+DESKTOP_LIB_DIR=java/client/build/nativeLibs
 SERVER_LIB_DIR=java/server/src/main/resources
 
 export CARGO_PROFILE_RELEASE_DEBUG=1 # enable line tables
@@ -71,8 +71,7 @@ build_desktop_for_arch () {
         fi
     fi
 
-    echo_then_run cargo build -p libsignal-jni --release ${FEATURES:+--features "${FEATURES[*]}"} --target "$1"
-#    echo_then_run cargo build -p libsignal-jni -p libsignal-jni-testing --release ${FEATURES:+--features "${FEATURES[*]}"} --target "$1"
+    echo_then_run cargo build -p libsignal-jni -p libsignal-jni-testing --release ${FEATURES:+--features "${FEATURES[*]}"} --target "$1"
     copy_built_library "target/${1}/release" signal_jni "$lib_dir" "signal_jni_${suffix}"
 #    copy_built_library "target/${1}/release" signal_jni_testing "$lib_dir" "signal_jni_testing_${suffix}"
 }

--- a/java/build_jni.sh
+++ b/java/build_jni.sh
@@ -71,9 +71,10 @@ build_desktop_for_arch () {
         fi
     fi
 
-    echo_then_run cargo build -p libsignal-jni -p libsignal-jni-testing --release ${FEATURES:+--features "${FEATURES[*]}"} --target "$1"
+    echo_then_run cargo build -p libsignal-jni --release ${FEATURES:+--features "${FEATURES[*]}"} --target "$1"
+#    echo_then_run cargo build -p libsignal-jni -p libsignal-jni-testing --release ${FEATURES:+--features "${FEATURES[*]}"} --target "$1"
     copy_built_library "target/${1}/release" signal_jni "$lib_dir" "signal_jni_${suffix}"
-    copy_built_library "target/${1}/release" signal_jni_testing "$lib_dir" "signal_jni_testing_${suffix}"
+#    copy_built_library "target/${1}/release" signal_jni_testing "$lib_dir" "signal_jni_testing_${suffix}"
 }
 
 android_abis=()

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -144,6 +144,25 @@ test {
 
 // MARK: Publishing
 
+def nativePlatforms = [
+    'darwin_aarch64': [ classifier: 'darwin_aarch64', libFileName: 'libsignal_jni_aarch64.dylib' ],
+    'darwin_x64': [ classifier: 'darwin_x86_64', libFileName: 'libsignal_jni_amd64.dylib' ],
+    'linux_aarch64': [ classifier: 'linux_aarch64', libFileName: 'libsignal_jni_aarch64.so' ],
+    'linux_x64': [ classifier: 'linux_x86_64', libFileName: 'libsignal_jni_amd64.so' ],
+    'win_x64': [ classifier: 'win_x86_64', libFileName: 'signal_jni_amd64.dll' ],
+]
+
+nativePlatforms.each { platform, props ->
+    project.task("nativeLib_${platform}", type: Jar) {
+        dependsOn processResources
+
+        archiveBaseName = archivesBaseName
+        from(layout.buildDirectory.dir('nativeLibs')) {
+            include props['libFileName']
+        }
+    }
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
@@ -172,6 +191,15 @@ publishing {
                     developer {
                         name = 'Signal Messenger LLC'
                     }
+                }
+            }
+        }
+
+        nativePlatforms.each { platform, props ->
+            maven(MavenPublication) {
+                artifactId = archivesBaseName
+                artifact project.tasks."nativeLib_${platform}" {
+                    archiveClassifier = props['classifier']
                 }
             }
         }

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -145,11 +145,11 @@ test {
 // MARK: Publishing
 
 def nativePlatforms = [
-    'darwin_aarch64': [ classifier: 'darwin_aarch64', libFileName: 'libsignal_jni_aarch64.dylib' ],
-    'darwin_x64': [ classifier: 'darwin_x86_64', libFileName: 'libsignal_jni_amd64.dylib' ],
-    'linux_aarch64': [ classifier: 'linux_aarch64', libFileName: 'libsignal_jni_aarch64.so' ],
-    'linux_x64': [ classifier: 'linux_x86_64', libFileName: 'libsignal_jni_amd64.so' ],
-    'win_x64': [ classifier: 'win_x86_64', libFileName: 'signal_jni_amd64.dll' ],
+    'darwin_aarch64': [ classifier: 'darwin-aarch64', libFileName: 'libsignal_jni_aarch64.dylib' ],
+    'darwin_x64': [ classifier: 'darwin-x86_64', libFileName: 'libsignal_jni_amd64.dylib' ],
+    'linux_aarch64': [ classifier: 'linux-aarch64', libFileName: 'libsignal_jni_aarch64.so' ],
+    'linux_x64': [ classifier: 'linux-x86_64', libFileName: 'libsignal_jni_amd64.so' ],
+    'win_x64': [ classifier: 'win-x86_64', libFileName: 'signal_jni_amd64.dll' ],
 ]
 
 nativePlatforms.each { platform, props ->


### PR DESCRIPTION
Before this PR, a single java jar artifact was created and published to the maven repository. This jar contained all the native libraries for each platform. As the native libraries tend to increase in size and the number of supported platforms increases, the size of the single artifact will increase too.

This PR takes care of this by removing the native libraries from the main jar artifact (the one without a classifier). It then creates a new artifact for each supported platform by only adding the native library for that platform. The artifact is then published using a platform specific classifier.

It also reduces the size by skipping copying the native testing libraries.